### PR TITLE
Prototype for Docs: Add build-time extension status injection for AsciiDoc guides

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3416,6 +3416,28 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>inject-extension-status</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipDocs}</skip>
+                            <!-- Don't wait for unkillable reference reaper threads -->
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                            <mainClass>io.quarkus.docs.generation.ExtensionStatusInjector</mainClass>
+                            <arguments>
+                                <!-- Path to extensions directory -->
+                                <argument>${project.basedir}/../extensions</argument>
+                                <!-- Path to copied AsciiDoc sources -->
+                                <argument>${project.basedir}/target/asciidoc/sources</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <MAVEN_CMD_LINE_ARGS>${env.MAVEN_CMD_LINE_ARGS}</MAVEN_CMD_LINE_ARGS>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate-doc-manifests</id>
                         <phase>package</phase>
                         <goals>

--- a/docs/src/main/java/io/quarkus/docs/generation/ExtensionStatusInjector.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/ExtensionStatusInjector.java
@@ -1,0 +1,352 @@
+package io.quarkus.docs.generation;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.quarkus.docs.generation.ExtensionStatusResolver.ExtensionStatus;
+
+/**
+ * Injects extension status attributes into AsciiDoc guide files based on the extensions
+ * they reference.
+ * <p>
+ * This tool:
+ * <ul>
+ * <li>Scans AsciiDoc files for the {@code :extensions:} attribute</li>
+ * <li>Looks up the status of each referenced extension</li>
+ * <li>Computes an effective status (most significant among all extensions)</li>
+ * <li>Injects or updates the {@code :extension-status:} attribute</li>
+ * </ul>
+ * <p>
+ * The injection only occurs if:
+ * <ul>
+ * <li>The guide has an {@code :extensions:} attribute</li>
+ * <li>No {@code :extension-status:} attribute is present, OR</li>
+ * <li>The existing status differs from the computed status (with a warning)</li>
+ * </ul>
+ */
+public class ExtensionStatusInjector {
+
+    // Pattern to match :extensions: attribute in document header
+    private static final Pattern EXTENSIONS_PATTERN = Pattern.compile(
+            "^:extensions:\\s*(.+)$", Pattern.MULTILINE);
+
+    // Pattern to match existing :extension-status: attribute
+    private static final Pattern EXTENSION_STATUS_PATTERN = Pattern.compile(
+            "^:extension-status:\\s*\"?([^\"\\n]+)\"?\\s*$", Pattern.MULTILINE);
+
+    // Pattern to find the include::_attributes.adoc[] line
+    private static final Pattern INCLUDE_ATTRIBUTES_PATTERN = Pattern.compile(
+            "^include::_attributes\\.adoc\\[]\\s*$", Pattern.MULTILINE);
+
+    private final ExtensionStatusResolver resolver;
+    private final Map<String, InjectionResult> results = new HashMap<>();
+
+    private boolean dryRun = false;
+    private boolean verbose = false;
+
+    public ExtensionStatusInjector(ExtensionStatusResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    public ExtensionStatusInjector setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+        return this;
+    }
+
+    public ExtensionStatusInjector setVerbose(boolean verbose) {
+        this.verbose = verbose;
+        return this;
+    }
+
+    /**
+     * Process all AsciiDoc files in the given directory.
+     *
+     * @param asciidocDir the directory containing AsciiDoc files
+     * @return this injector for method chaining
+     * @throws IOException if an I/O error occurs
+     */
+    public ExtensionStatusInjector processDirectory(Path asciidocDir) throws IOException {
+        if (!Files.isDirectory(asciidocDir)) {
+            throw new IllegalArgumentException("Not a directory: " + asciidocDir);
+        }
+
+        System.out.println("[INFO] Processing AsciiDoc files in: " + asciidocDir);
+
+        try (Stream<Path> files = Files.list(asciidocDir)) {
+            files.filter(this::isGuideFile)
+                    .forEach(this::processFile);
+        }
+
+        return this;
+    }
+
+    private boolean isGuideFile(Path path) {
+        if (!Files.isRegularFile(path)) {
+            return false;
+        }
+        String filename = path.getFileName().toString();
+        // Skip templates, includes, and other special files
+        return filename.endsWith(".adoc")
+                && !filename.startsWith("_")
+                && !filename.equals("README.adoc");
+    }
+
+    private void processFile(Path path) {
+        try {
+            String content = Files.readString(path);
+            String filename = path.getFileName().toString();
+
+            // Check if this file has an :extensions: attribute
+            Matcher extensionsMatcher = EXTENSIONS_PATTERN.matcher(content);
+            if (!extensionsMatcher.find()) {
+                if (verbose) {
+                    System.out.println("[DEBUG] No :extensions: attribute in: " + filename);
+                }
+                results.put(filename, InjectionResult.noExtensions());
+                return;
+            }
+
+            String extensions = extensionsMatcher.group(1).trim();
+
+            // Compute effective status from extensions
+            Optional<ExtensionStatus> computedStatus = resolver.computeEffectiveStatus(extensions);
+            if (computedStatus.isEmpty()) {
+                if (verbose) {
+                    System.out.println("[DEBUG] No status found for extensions in: " + filename);
+                }
+                results.put(filename, InjectionResult.noStatusFound(extensions));
+                return;
+            }
+
+            // Check for existing :extension-status: attribute
+            Matcher statusMatcher = EXTENSION_STATUS_PATTERN.matcher(content);
+            boolean hasExistingStatus = statusMatcher.find();
+
+            if (hasExistingStatus) {
+                String existingStatus = statusMatcher.group(1).trim().toLowerCase();
+                String computedStatusId = computedStatus.get().getId();
+
+                if (existingStatus.equals(computedStatusId)) {
+                    if (verbose) {
+                        System.out.println("[DEBUG] Status already correct in: " + filename + " (" + existingStatus + ")");
+                    }
+                    results.put(filename, InjectionResult.alreadyCorrect(existingStatus));
+                    return;
+                } else {
+                    // Status mismatch - warn but update
+                    System.out.println("[WARN] Status mismatch in " + filename +
+                            ": declared=" + existingStatus + ", computed=" + computedStatusId);
+                    results.put(filename, InjectionResult.mismatch(existingStatus, computedStatusId));
+
+                    if (!dryRun) {
+                        // Replace existing status with computed status
+                        String updatedContent = statusMatcher.replaceFirst(
+                                ":extension-status: " + computedStatusId);
+                        Files.writeString(path, updatedContent);
+                        System.out.println("[INFO] Updated status in: " + filename);
+                    }
+                    return;
+                }
+            }
+
+            // No existing status - inject one
+            String statusLine = ":extension-status: " + computedStatus.get().getId();
+
+            // Find the best insertion point (after include::_attributes.adoc[])
+            Matcher includeMatcher = INCLUDE_ATTRIBUTES_PATTERN.matcher(content);
+            String updatedContent;
+
+            if (includeMatcher.find()) {
+                // Insert after the include::_attributes.adoc[] line
+                int insertPos = includeMatcher.end();
+                updatedContent = content.substring(0, insertPos) + "\n" + statusLine + content.substring(insertPos);
+            } else {
+                // Fallback: insert after the title line
+                int titleEnd = content.indexOf("\n", content.indexOf("\n= "));
+                if (titleEnd > 0) {
+                    updatedContent = content.substring(0, titleEnd + 1) + statusLine + "\n" + content.substring(titleEnd + 1);
+                } else {
+                    System.err.println("[WARN] Could not find insertion point in: " + filename);
+                    results.put(filename, InjectionResult.insertionFailed());
+                    return;
+                }
+            }
+
+            results.put(filename, InjectionResult.injected(computedStatus.get().getId(), extensions));
+
+            if (!dryRun) {
+                Files.writeString(path, updatedContent);
+                System.out.println("[INFO] Injected status '" + computedStatus.get().getId() + "' in: " + filename);
+            } else {
+                System.out.println("[DRY-RUN] Would inject status '" + computedStatus.get().getId() + "' in: " + filename);
+            }
+
+        } catch (IOException e) {
+            System.err.println("[ERROR] Failed to process file: " + path + " - " + e.getMessage());
+            results.put(path.getFileName().toString(), InjectionResult.error(e.getMessage()));
+        }
+    }
+
+    /**
+     * Prints a summary of the injection results.
+     */
+    public void printSummary() {
+        int injected = 0;
+        int updated = 0;
+        int correct = 0;
+        int noExtensions = 0;
+        int noStatus = 0;
+        int errors = 0;
+
+        for (InjectionResult result : results.values()) {
+            switch (result.type) {
+                case INJECTED:
+                    injected++;
+                    break;
+                case MISMATCH:
+                    updated++;
+                    break;
+                case ALREADY_CORRECT:
+                    correct++;
+                    break;
+                case NO_EXTENSIONS:
+                    noExtensions++;
+                    break;
+                case NO_STATUS_FOUND:
+                    noStatus++;
+                    break;
+                case ERROR:
+                case INSERTION_FAILED:
+                    errors++;
+                    break;
+            }
+        }
+
+        System.out.println("\n=== Extension Status Injection Summary ===");
+        System.out.println("  Injected new status:     " + injected);
+        System.out.println("  Updated mismatched:      " + updated);
+        System.out.println("  Already correct:         " + correct);
+        System.out.println("  No :extensions: attr:    " + noExtensions);
+        System.out.println("  Extensions without status: " + noStatus);
+        System.out.println("  Errors:                  " + errors);
+        System.out.println("  Total processed:         " + results.size());
+    }
+
+    /**
+     * Returns the injection results for all processed files.
+     */
+    public Map<String, InjectionResult> getResults() {
+        return results;
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("Usage: ExtensionStatusInjector <extensions-dir> <asciidoc-dir> [--dry-run] [--verbose]");
+            System.err.println("  extensions-dir: Path to the Quarkus extensions directory");
+            System.err.println("  asciidoc-dir:   Path to the AsciiDoc sources directory");
+            System.err.println("  --dry-run:      Print what would be done without making changes");
+            System.err.println("  --verbose:      Print detailed processing information");
+            System.exit(1);
+        }
+
+        Path extensionsDir = Paths.get(args[0]);
+        Path asciidocDir = Paths.get(args[1]);
+        boolean dryRun = false;
+        boolean verbose = false;
+
+        for (int i = 2; i < args.length; i++) {
+            if ("--dry-run".equals(args[i])) {
+                dryRun = true;
+            } else if ("--verbose".equals(args[i])) {
+                verbose = true;
+            }
+        }
+
+        System.out.println("[INFO] Extension Status Injector");
+        System.out.println("[INFO] Extensions directory: " + extensionsDir);
+        System.out.println("[INFO] AsciiDoc directory: " + asciidocDir);
+        if (dryRun) {
+            System.out.println("[INFO] Running in DRY-RUN mode - no files will be modified");
+        }
+
+        // Build the extension status resolver
+        ExtensionStatusResolver resolver = new ExtensionStatusResolver()
+                .scanExtensions(extensionsDir);
+
+        if (verbose) {
+            System.out.println("[DEBUG] Resolved extension statuses:");
+            resolver.printAllStatuses();
+        }
+
+        // Process AsciiDoc files
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .setDryRun(dryRun)
+                .setVerbose(verbose)
+                .processDirectory(asciidocDir);
+
+        injector.printSummary();
+    }
+
+    /**
+     * Result of processing a single file.
+     */
+    public static class InjectionResult {
+        public enum Type {
+            INJECTED,
+            MISMATCH,
+            ALREADY_CORRECT,
+            NO_EXTENSIONS,
+            NO_STATUS_FOUND,
+            INSERTION_FAILED,
+            ERROR
+        }
+
+        public final Type type;
+        public final String details;
+        public final String extensions;
+
+        private InjectionResult(Type type, String details, String extensions) {
+            this.type = type;
+            this.details = details;
+            this.extensions = extensions;
+        }
+
+        public static InjectionResult injected(String status, String extensions) {
+            return new InjectionResult(Type.INJECTED, status, extensions);
+        }
+
+        public static InjectionResult mismatch(String existing, String computed) {
+            return new InjectionResult(Type.MISMATCH, existing + " -> " + computed, null);
+        }
+
+        public static InjectionResult alreadyCorrect(String status) {
+            return new InjectionResult(Type.ALREADY_CORRECT, status, null);
+        }
+
+        public static InjectionResult noExtensions() {
+            return new InjectionResult(Type.NO_EXTENSIONS, null, null);
+        }
+
+        public static InjectionResult noStatusFound(String extensions) {
+            return new InjectionResult(Type.NO_STATUS_FOUND, null, extensions);
+        }
+
+        public static InjectionResult insertionFailed() {
+            return new InjectionResult(Type.INSERTION_FAILED, null, null);
+        }
+
+        public static InjectionResult error(String message) {
+            return new InjectionResult(Type.ERROR, message, null);
+        }
+    }
+}

--- a/docs/src/main/java/io/quarkus/docs/generation/ExtensionStatusResolver.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/ExtensionStatusResolver.java
@@ -1,0 +1,282 @@
+package io.quarkus.docs.generation;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Resolves extension status from quarkus-extension.yaml files in the extensions directory.
+ * <p>
+ * This class scans the extensions directory structure to build a mapping from extension
+ * artifact coordinates (groupId:artifactId) to their declared status (stable, preview,
+ * experimental, deprecated).
+ */
+public class ExtensionStatusResolver {
+
+    private static final String EXTENSION_YAML = "quarkus-extension.yaml";
+    private static final String META_INF = "META-INF";
+    private static final String RESOURCES = "resources";
+    private static final String MAIN = "main";
+    private static final String SRC = "src";
+    private static final String RUNTIME = "runtime";
+
+    private final Map<String, ExtensionStatus> extensionStatuses;
+    private final ObjectMapper yamlMapper;
+
+    public enum ExtensionStatus {
+        STABLE("stable", 0),
+        PREVIEW("preview", 1),
+        EXPERIMENTAL("experimental", 2),
+        DEPRECATED("deprecated", 3);
+
+        private final String id;
+        private final int priority;
+
+        ExtensionStatus(String id, int priority) {
+            this.id = id;
+            this.priority = priority;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * Priority for determining the "most significant" status when multiple extensions
+         * are involved. Higher priority means the status is more significant and should
+         * take precedence.
+         */
+        public int getPriority() {
+            return priority;
+        }
+
+        public static Optional<ExtensionStatus> fromString(String status) {
+            if (status == null || status.isBlank()) {
+                return Optional.empty();
+            }
+            String normalized = status.toLowerCase().trim();
+            for (ExtensionStatus s : values()) {
+                if (s.id.equals(normalized)) {
+                    return Optional.of(s);
+                }
+            }
+            return Optional.empty();
+        }
+
+        /**
+         * Returns the more significant status between two statuses.
+         * Experimental > Preview > Deprecated > Stable
+         */
+        public static ExtensionStatus mostSignificant(ExtensionStatus a, ExtensionStatus b) {
+            if (a == null) return b;
+            if (b == null) return a;
+            return a.priority >= b.priority ? a : b;
+        }
+    }
+
+    public ExtensionStatusResolver() {
+        this.extensionStatuses = new HashMap<>();
+        this.yamlMapper = new ObjectMapper(new YAMLFactory());
+    }
+
+    /**
+     * Scans the extensions directory and builds the extension status map.
+     *
+     * @param extensionsDir the root extensions directory (e.g., /path/to/quarkus/extensions)
+     * @return this resolver for method chaining
+     * @throws IOException if an I/O error occurs while scanning
+     */
+    public ExtensionStatusResolver scanExtensions(Path extensionsDir) throws IOException {
+        if (!Files.isDirectory(extensionsDir)) {
+            System.err.println("[WARN] Extensions directory does not exist: " + extensionsDir);
+            return this;
+        }
+
+        System.out.println("[INFO] Scanning extensions directory: " + extensionsDir);
+
+        try (Stream<Path> walker = Files.walk(extensionsDir, 10)) {
+            walker.filter(this::isExtensionYaml)
+                    .forEach(this::parseExtensionYaml);
+        }
+
+        System.out.println("[INFO] Found " + extensionStatuses.size() + " extensions with status information");
+        return this;
+    }
+
+    private boolean isExtensionYaml(Path path) {
+        if (!Files.isRegularFile(path)) {
+            return false;
+        }
+        // Match pattern: extensions/**/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+        String pathStr = path.toString();
+        return pathStr.endsWith(EXTENSION_YAML)
+                && path.getParent() != null
+                && path.getParent().getFileName().toString().equals(META_INF)
+                && pathStr.contains(RUNTIME);
+    }
+
+    private void parseExtensionYaml(Path yamlPath) {
+        try {
+            JsonNode root = yamlMapper.readTree(yamlPath.toFile());
+
+            // Extract artifact coordinates
+            JsonNode artifactNode = root.get("artifact");
+            if (artifactNode == null) {
+                return;
+            }
+
+            String artifact = artifactNode.asText();
+            // Artifact format: ${project.groupId}:${project.artifactId}:${project.version}
+            // or actual coordinates like io.quarkus:quarkus-redis-client:999-SNAPSHOT
+            // We need to derive the actual groupId:artifactId from the path
+
+            String artifactId = deriveArtifactId(yamlPath);
+            if (artifactId == null) {
+                return;
+            }
+
+            // Default groupId for Quarkus core extensions
+            String groupId = "io.quarkus";
+            String gav = groupId + ":" + artifactId;
+
+            // Extract status from metadata
+            JsonNode metadataNode = root.get("metadata");
+            if (metadataNode != null) {
+                JsonNode statusNode = metadataNode.get("status");
+                if (statusNode != null) {
+                    String statusStr = statusNode.asText();
+                    ExtensionStatus.fromString(statusStr).ifPresent(status -> {
+                        extensionStatuses.put(gav, status);
+                    });
+                }
+            }
+
+        } catch (IOException e) {
+            System.err.println("[WARN] Failed to parse extension YAML: " + yamlPath + " - " + e.getMessage());
+        }
+    }
+
+    /**
+     * Derives the artifactId from the extension YAML path.
+     * The path structure is: extensions/{extension-name}/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+     * or: extensions/{extension-name}/{sub-module}/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+     */
+    private String deriveArtifactId(Path yamlPath) {
+        // Navigate up to find the runtime module directory
+        Path current = yamlPath.getParent(); // META-INF
+        if (current == null) return null;
+        current = current.getParent(); // resources
+        if (current == null) return null;
+        current = current.getParent(); // main
+        if (current == null) return null;
+        current = current.getParent(); // src
+        if (current == null) return null;
+        current = current.getParent(); // runtime
+        if (current == null) return null;
+
+        // Now current is the runtime directory
+        Path runtimeDir = current;
+        Path extensionDir = runtimeDir.getParent();
+        if (extensionDir == null) return null;
+
+        // Build the artifact ID based on the directory structure
+        StringBuilder artifactId = new StringBuilder("quarkus-");
+
+        // Check if this is a nested extension (e.g., extensions/container-image/container-image-docker)
+        Path extensionsRoot = extensionDir.getParent();
+        if (extensionsRoot != null && !extensionsRoot.getFileName().toString().equals("extensions")) {
+            // This is a nested extension
+            Path parentExtensionDir = extensionsRoot;
+            Path grandParent = parentExtensionDir.getParent();
+            if (grandParent != null && grandParent.getFileName().toString().equals("extensions")) {
+                // Pattern: extensions/parent/child/runtime
+                artifactId.append(extensionDir.getFileName().toString());
+            } else {
+                // Deeper nesting or different structure
+                artifactId.append(extensionDir.getFileName().toString());
+            }
+        } else {
+            // Simple extension: extensions/extension-name/runtime
+            artifactId.append(extensionDir.getFileName().toString());
+        }
+
+        return artifactId.toString();
+    }
+
+    /**
+     * Gets the status for a specific extension.
+     *
+     * @param groupId    the extension's group ID (e.g., "io.quarkus")
+     * @param artifactId the extension's artifact ID (e.g., "quarkus-redis-client")
+     * @return the extension status, or empty if not found or no status declared
+     */
+    public Optional<ExtensionStatus> getStatus(String groupId, String artifactId) {
+        String gav = groupId + ":" + artifactId;
+        return Optional.ofNullable(extensionStatuses.get(gav));
+    }
+
+    /**
+     * Gets the status for a specific extension using the full GAV string.
+     *
+     * @param gav the extension's group:artifact coordinates (e.g., "io.quarkus:quarkus-redis-client")
+     * @return the extension status, or empty if not found or no status declared
+     */
+    public Optional<ExtensionStatus> getStatus(String gav) {
+        // Handle full GAV with version (groupId:artifactId:version)
+        String[] parts = gav.split(":");
+        if (parts.length >= 2) {
+            String normalizedGav = parts[0] + ":" + parts[1];
+            return Optional.ofNullable(extensionStatuses.get(normalizedGav));
+        }
+        return Optional.ofNullable(extensionStatuses.get(gav));
+    }
+
+    /**
+     * Returns an unmodifiable view of all extension statuses.
+     */
+    public Map<String, ExtensionStatus> getAllStatuses() {
+        return Collections.unmodifiableMap(extensionStatuses);
+    }
+
+    /**
+     * Computes the effective status for a list of extensions.
+     * Uses the "most significant" status among all extensions.
+     *
+     * @param extensions comma-separated list of extension GAVs
+     * @return the most significant status, or empty if no extensions have status
+     */
+    public Optional<ExtensionStatus> computeEffectiveStatus(String extensions) {
+        if (extensions == null || extensions.isBlank()) {
+            return Optional.empty();
+        }
+
+        ExtensionStatus result = null;
+        for (String ext : extensions.split(",")) {
+            String trimmed = ext.trim();
+            Optional<ExtensionStatus> status = getStatus(trimmed);
+            if (status.isPresent()) {
+                result = ExtensionStatus.mostSignificant(result, status.get());
+            }
+        }
+
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * For testing and debugging: prints all resolved extensions.
+     */
+    public void printAllStatuses() {
+        extensionStatuses.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> System.out.println("  " + entry.getKey() + " -> " + entry.getValue().getId()));
+    }
+}

--- a/docs/src/test/java/io/quarkus/docs/ExtensionStatusInjectorTest.java
+++ b/docs/src/test/java/io/quarkus/docs/ExtensionStatusInjectorTest.java
@@ -1,0 +1,273 @@
+package io.quarkus.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.docs.generation.ExtensionStatusInjector;
+import io.quarkus.docs.generation.ExtensionStatusInjector.InjectionResult;
+import io.quarkus.docs.generation.ExtensionStatusResolver;
+
+public class ExtensionStatusInjectorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path extensionsDir;
+    private Path asciidocDir;
+    private ExtensionStatusResolver resolver;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        extensionsDir = tempDir.resolve("extensions");
+        asciidocDir = tempDir.resolve("asciidoc");
+        Files.createDirectories(extensionsDir);
+        Files.createDirectories(asciidocDir);
+
+        // Create some test extensions
+        createExtension("stable-ext", "stable");
+        createExtension("preview-ext", "preview");
+        createExtension("experimental-ext", "experimental");
+
+        resolver = new ExtensionStatusResolver().scanExtensions(extensionsDir);
+    }
+
+    @Test
+    void testInjectStatusIntoGuideWithoutStatus() throws IOException {
+        String guideContent = """
+                ////
+                This guide is maintained in the main Quarkus repository
+                ////
+                = My Guide
+                include::_attributes.adoc[]
+                :categories: data
+                :extensions: io.quarkus:quarkus-preview-ext
+
+                This is the preamble.
+                """;
+        Path guidePath = asciidocDir.resolve("my-guide.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        Map<String, InjectionResult> results = injector.getResults();
+        assertEquals(InjectionResult.Type.INJECTED, results.get("my-guide.adoc").type);
+
+        // Verify the file was updated
+        String updatedContent = Files.readString(guidePath);
+        assertTrue(updatedContent.contains(":extension-status: preview"));
+    }
+
+    @Test
+    void testInjectStatusAfterIncludeAttributes() throws IOException {
+        String guideContent = """
+                = My Guide
+                include::_attributes.adoc[]
+                :categories: data
+                :extensions: io.quarkus:quarkus-stable-ext
+
+                Preamble text.
+                """;
+        Path guidePath = asciidocDir.resolve("test-guide.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        new ExtensionStatusInjector(resolver).processDirectory(asciidocDir);
+
+        String updatedContent = Files.readString(guidePath);
+        // Status should be inserted after include::_attributes.adoc[]
+        int includePos = updatedContent.indexOf("include::_attributes.adoc[]");
+        int statusPos = updatedContent.indexOf(":extension-status: stable");
+        assertTrue(statusPos > includePos, "Status should be after include::_attributes.adoc[]");
+    }
+
+    @Test
+    void testSkipGuideWithNoExtensions() throws IOException {
+        String guideContent = """
+                = My Guide
+                include::_attributes.adoc[]
+                :categories: data
+
+                No extensions attribute here.
+                """;
+        Path guidePath = asciidocDir.resolve("no-extensions.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        Map<String, InjectionResult> results = injector.getResults();
+        assertEquals(InjectionResult.Type.NO_EXTENSIONS, results.get("no-extensions.adoc").type);
+
+        // File should not be modified
+        String content = Files.readString(guidePath);
+        assertFalse(content.contains(":extension-status:"));
+    }
+
+    @Test
+    void testPreserveCorrectExistingStatus() throws IOException {
+        String guideContent = """
+                = My Guide
+                :extension-status: preview
+                include::_attributes.adoc[]
+                :extensions: io.quarkus:quarkus-preview-ext
+
+                Preamble.
+                """;
+        Path guidePath = asciidocDir.resolve("correct-status.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        Map<String, InjectionResult> results = injector.getResults();
+        assertEquals(InjectionResult.Type.ALREADY_CORRECT, results.get("correct-status.adoc").type);
+    }
+
+    @Test
+    void testUpdateMismatchedStatus() throws IOException {
+        String guideContent = """
+                = My Guide
+                :extension-status: stable
+                include::_attributes.adoc[]
+                :extensions: io.quarkus:quarkus-experimental-ext
+
+                Preamble.
+                """;
+        Path guidePath = asciidocDir.resolve("mismatched-status.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        Map<String, InjectionResult> results = injector.getResults();
+        assertEquals(InjectionResult.Type.MISMATCH, results.get("mismatched-status.adoc").type);
+
+        // File should be updated
+        String updatedContent = Files.readString(guidePath);
+        assertTrue(updatedContent.contains(":extension-status: experimental"));
+        assertFalse(updatedContent.contains(":extension-status: stable"));
+    }
+
+    @Test
+    void testDryRunMode() throws IOException {
+        String originalContent = """
+                = My Guide
+                include::_attributes.adoc[]
+                :extensions: io.quarkus:quarkus-preview-ext
+
+                Preamble.
+                """;
+        Path guidePath = asciidocDir.resolve("dry-run-test.adoc");
+        Files.writeString(guidePath, originalContent);
+
+        new ExtensionStatusInjector(resolver)
+                .setDryRun(true)
+                .processDirectory(asciidocDir);
+
+        // File should NOT be modified in dry-run mode
+        String content = Files.readString(guidePath);
+        assertEquals(originalContent, content);
+    }
+
+    @Test
+    void testMultipleExtensionsMostSignificantStatus() throws IOException {
+        String guideContent = """
+                = Multi Extension Guide
+                include::_attributes.adoc[]
+                :extensions: io.quarkus:quarkus-stable-ext,io.quarkus:quarkus-preview-ext,io.quarkus:quarkus-experimental-ext
+
+                This guide covers multiple extensions.
+                """;
+        Path guidePath = asciidocDir.resolve("multi-ext.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        new ExtensionStatusInjector(resolver).processDirectory(asciidocDir);
+
+        String updatedContent = Files.readString(guidePath);
+        // Should use the most significant status (experimental)
+        assertTrue(updatedContent.contains(":extension-status: experimental"));
+    }
+
+    @Test
+    void testSkipTemplateFiles() throws IOException {
+        String templateContent = """
+                = Template
+                include::_attributes.adoc[]
+                :extension-status: preview
+                :extensions: io.quarkus:quarkus-preview-ext
+
+                Template content.
+                """;
+        Path templatePath = asciidocDir.resolve("_template.adoc");
+        Files.writeString(templatePath, templateContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        // Template files (starting with _) should be skipped
+        assertFalse(injector.getResults().containsKey("_template.adoc"));
+    }
+
+    @Test
+    void testSkipReadmeFile() throws IOException {
+        String readmeContent = """
+                = README
+                include::_attributes.adoc[]
+                :extensions: io.quarkus:quarkus-preview-ext
+
+                Readme content.
+                """;
+        Path readmePath = asciidocDir.resolve("README.adoc");
+        Files.writeString(readmePath, readmeContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        // README should be skipped
+        assertFalse(injector.getResults().containsKey("README.adoc"));
+    }
+
+    @Test
+    void testHandleQuotedStatus() throws IOException {
+        String guideContent = """
+                = My Guide
+                :extension-status: "experimental"
+                include::_attributes.adoc[]
+                :extensions: io.quarkus:quarkus-experimental-ext
+
+                Preamble.
+                """;
+        Path guidePath = asciidocDir.resolve("quoted-status.adoc");
+        Files.writeString(guidePath, guideContent);
+
+        ExtensionStatusInjector injector = new ExtensionStatusInjector(resolver)
+                .processDirectory(asciidocDir);
+
+        Map<String, InjectionResult> results = injector.getResults();
+        assertEquals(InjectionResult.Type.ALREADY_CORRECT, results.get("quoted-status.adoc").type);
+    }
+
+    private void createExtension(String name, String status) throws IOException {
+        Path extensionDir = extensionsDir.resolve(name + "/runtime/src/main/resources/META-INF");
+        Files.createDirectories(extensionDir);
+
+        String yaml = """
+                ---
+                artifact: ${project.groupId}:${project.artifactId}:${project.version}
+                name: "%s"
+                metadata:
+                  status: "%s"
+                """.formatted(name, status);
+        Files.writeString(extensionDir.resolve("quarkus-extension.yaml"), yaml);
+    }
+}

--- a/docs/src/test/java/io/quarkus/docs/ExtensionStatusResolverTest.java
+++ b/docs/src/test/java/io/quarkus/docs/ExtensionStatusResolverTest.java
@@ -1,0 +1,215 @@
+package io.quarkus.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.docs.generation.ExtensionStatusResolver;
+import io.quarkus.docs.generation.ExtensionStatusResolver.ExtensionStatus;
+
+public class ExtensionStatusResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ExtensionStatusResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new ExtensionStatusResolver();
+    }
+
+    @Test
+    void testStatusFromString() {
+        assertEquals(Optional.of(ExtensionStatus.STABLE), ExtensionStatus.fromString("stable"));
+        assertEquals(Optional.of(ExtensionStatus.PREVIEW), ExtensionStatus.fromString("preview"));
+        assertEquals(Optional.of(ExtensionStatus.EXPERIMENTAL), ExtensionStatus.fromString("experimental"));
+        assertEquals(Optional.of(ExtensionStatus.DEPRECATED), ExtensionStatus.fromString("deprecated"));
+
+        // Case insensitive
+        assertEquals(Optional.of(ExtensionStatus.STABLE), ExtensionStatus.fromString("STABLE"));
+        assertEquals(Optional.of(ExtensionStatus.PREVIEW), ExtensionStatus.fromString("Preview"));
+
+        // Invalid values
+        assertTrue(ExtensionStatus.fromString(null).isEmpty());
+        assertTrue(ExtensionStatus.fromString("").isEmpty());
+        assertTrue(ExtensionStatus.fromString("unknown").isEmpty());
+    }
+
+    @Test
+    void testMostSignificant() {
+        // Experimental is most significant
+        assertEquals(ExtensionStatus.EXPERIMENTAL,
+                ExtensionStatus.mostSignificant(ExtensionStatus.STABLE, ExtensionStatus.EXPERIMENTAL));
+        assertEquals(ExtensionStatus.EXPERIMENTAL,
+                ExtensionStatus.mostSignificant(ExtensionStatus.EXPERIMENTAL, ExtensionStatus.STABLE));
+
+        // Preview is more significant than stable
+        assertEquals(ExtensionStatus.PREVIEW,
+                ExtensionStatus.mostSignificant(ExtensionStatus.STABLE, ExtensionStatus.PREVIEW));
+
+        // Deprecated is more significant than stable
+        assertEquals(ExtensionStatus.DEPRECATED,
+                ExtensionStatus.mostSignificant(ExtensionStatus.STABLE, ExtensionStatus.DEPRECATED));
+
+        // Experimental is more significant than preview
+        assertEquals(ExtensionStatus.EXPERIMENTAL,
+                ExtensionStatus.mostSignificant(ExtensionStatus.PREVIEW, ExtensionStatus.EXPERIMENTAL));
+
+        // Null handling
+        assertEquals(ExtensionStatus.STABLE, ExtensionStatus.mostSignificant(null, ExtensionStatus.STABLE));
+        assertEquals(ExtensionStatus.STABLE, ExtensionStatus.mostSignificant(ExtensionStatus.STABLE, null));
+    }
+
+    @Test
+    void testScanExtensions() throws IOException {
+        // Create a mock extension structure
+        Path extensionDir = tempDir.resolve("extensions/my-extension/runtime/src/main/resources/META-INF");
+        Files.createDirectories(extensionDir);
+
+        String yaml = """
+                ---
+                artifact: ${project.groupId}:${project.artifactId}:${project.version}
+                name: "My Extension"
+                metadata:
+                  status: "preview"
+                """;
+        Files.writeString(extensionDir.resolve("quarkus-extension.yaml"), yaml);
+
+        resolver.scanExtensions(tempDir.resolve("extensions"));
+
+        Optional<ExtensionStatus> status = resolver.getStatus("io.quarkus", "quarkus-my-extension");
+        assertTrue(status.isPresent());
+        assertEquals(ExtensionStatus.PREVIEW, status.get());
+    }
+
+    @Test
+    void testScanExtensionsWithStableStatus() throws IOException {
+        Path extensionDir = tempDir.resolve("extensions/redis-client/runtime/src/main/resources/META-INF");
+        Files.createDirectories(extensionDir);
+
+        String yaml = """
+                ---
+                artifact: ${project.groupId}:${project.artifactId}:${project.version}
+                name: "Redis Client"
+                metadata:
+                  status: "stable"
+                """;
+        Files.writeString(extensionDir.resolve("quarkus-extension.yaml"), yaml);
+
+        resolver.scanExtensions(tempDir.resolve("extensions"));
+
+        Optional<ExtensionStatus> status = resolver.getStatus("io.quarkus:quarkus-redis-client");
+        assertTrue(status.isPresent());
+        assertEquals(ExtensionStatus.STABLE, status.get());
+    }
+
+    @Test
+    void testScanExtensionsWithNoStatus() throws IOException {
+        Path extensionDir = tempDir.resolve("extensions/no-status/runtime/src/main/resources/META-INF");
+        Files.createDirectories(extensionDir);
+
+        String yaml = """
+                ---
+                artifact: ${project.groupId}:${project.artifactId}:${project.version}
+                name: "No Status Extension"
+                metadata:
+                  keywords:
+                    - "test"
+                """;
+        Files.writeString(extensionDir.resolve("quarkus-extension.yaml"), yaml);
+
+        resolver.scanExtensions(tempDir.resolve("extensions"));
+
+        Optional<ExtensionStatus> status = resolver.getStatus("io.quarkus:quarkus-no-status");
+        assertFalse(status.isPresent());
+    }
+
+    @Test
+    void testComputeEffectiveStatus() throws IOException {
+        // Create multiple extensions with different statuses
+        createExtension("stable-ext", "stable");
+        createExtension("preview-ext", "preview");
+        createExtension("experimental-ext", "experimental");
+
+        resolver.scanExtensions(tempDir.resolve("extensions"));
+
+        // Single extension
+        assertEquals(Optional.of(ExtensionStatus.STABLE),
+                resolver.computeEffectiveStatus("io.quarkus:quarkus-stable-ext"));
+
+        // Multiple extensions - should return most significant
+        assertEquals(Optional.of(ExtensionStatus.PREVIEW),
+                resolver.computeEffectiveStatus("io.quarkus:quarkus-stable-ext,io.quarkus:quarkus-preview-ext"));
+
+        assertEquals(Optional.of(ExtensionStatus.EXPERIMENTAL),
+                resolver.computeEffectiveStatus(
+                        "io.quarkus:quarkus-stable-ext,io.quarkus:quarkus-preview-ext,io.quarkus:quarkus-experimental-ext"));
+    }
+
+    @Test
+    void testComputeEffectiveStatusWithUnknownExtension() throws IOException {
+        createExtension("known-ext", "stable");
+        resolver.scanExtensions(tempDir.resolve("extensions"));
+
+        // Mix of known and unknown extensions
+        assertEquals(Optional.of(ExtensionStatus.STABLE),
+                resolver.computeEffectiveStatus("io.quarkus:quarkus-known-ext,io.quarkus:quarkus-unknown-ext"));
+
+        // Only unknown extensions
+        assertTrue(resolver.computeEffectiveStatus("io.quarkus:quarkus-unknown-ext").isEmpty());
+    }
+
+    @Test
+    void testEmptyExtensionsList() {
+        assertTrue(resolver.computeEffectiveStatus(null).isEmpty());
+        assertTrue(resolver.computeEffectiveStatus("").isEmpty());
+        assertTrue(resolver.computeEffectiveStatus("   ").isEmpty());
+    }
+
+    private void createExtension(String name, String status) throws IOException {
+        Path extensionDir = tempDir.resolve("extensions/" + name + "/runtime/src/main/resources/META-INF");
+        Files.createDirectories(extensionDir);
+
+        String yaml = """
+                ---
+                artifact: ${project.groupId}:${project.artifactId}:${project.version}
+                name: "%s"
+                metadata:
+                  status: "%s"
+                """.formatted(name, status);
+        Files.writeString(extensionDir.resolve("quarkus-extension.yaml"), yaml);
+    }
+
+    @Test
+    void testScanRealExtensionsDirectory() throws IOException {
+        // This test uses the actual extensions directory if available
+        Path realExtensionsDir = Path.of("../extensions");
+        if (!Files.isDirectory(realExtensionsDir)) {
+            return; // Skip if not running from docs directory
+        }
+
+        ExtensionStatusResolver realResolver = new ExtensionStatusResolver()
+                .scanExtensions(realExtensionsDir);
+
+        // Verify some known extensions
+        Optional<ExtensionStatus> redisStatus = realResolver.getStatus("io.quarkus:quarkus-redis-client");
+        if (redisStatus.isPresent()) {
+            assertEquals(ExtensionStatus.STABLE, redisStatus.get());
+        }
+
+        Optional<ExtensionStatus> hibernateReactiveStatus = realResolver.getStatus("io.quarkus:quarkus-hibernate-reactive");
+        if (hibernateReactiveStatus.isPresent()) {
+            assertEquals(ExtensionStatus.PREVIEW, hibernateReactiveStatus.get());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces automatic injection of extension status attributes
into AsciiDoc guide files based on the extensions they reference. Currently,
guide authors manually add `:extension-status:` attributes, which leads to
drift between guides and actual extension metadata.

## Problem

The `:extension-status:` attribute in guides (stable, preview, experimental,
deprecated) is manually maintained and often drifts out of sync with the
actual extension status defined in `quarkus-extension.yaml` files. This was
highlighted in https://github.com/quarkusio/quarkusio.github.io/pull/2508.

## Solution

Two new Java classes in the docs build pipeline:

- **ExtensionStatusResolver**: Scans `extensions/` directory for
  `quarkus-extension.yaml` files and builds a mapping of extension GAV
  to status. Provides `computeEffectiveStatus()` for multi-extension guides.

- **ExtensionStatusInjector**: Processes AsciiDoc files, reads the
  `:extensions:` attribute, computes effective status, and injects/updates
  the `:extension-status:` attribute.

The injector runs in the `prepare-package` phase, after resources are copied
but before YamlMetadataGenerator runs.

## Multi-Extension Status Resolution

For guides covering multiple extensions (e.g., datasource.adoc with 14
extensions), the tool uses the "most significant" status:
  experimental > preview > deprecated > stable

This ensures users see the most important stability warning.

**Alternative approach** (not yet implemented): Display individual statuses
for each extension mentioned, allowing more granular status information.

## Test Results (dry-run against current codebase)

| Metric                      | Count |
|-----------------------------|-------|
| Would inject new status     | 132   |
| Status mismatches detected  | 11    |
| Already correct             | 17    |
| No :extensions: attribute   | 80    |
| Extensions without status   | 27    |
| Total processed             | 267   |

## Key Findings

The tool detected **11 status mismatches** where guide's manual status
differs from computed value:

- funqy-*.adoc: declared=preview, computed=experimental
- opentelemetry-metrics.adoc: declared=preview, computed=stable
- opentelemetry-logging.adoc: declared=preview, computed=stable
- security-webauthn.adoc: declared=preview, computed=experimental
- aws-lambda-http.adoc: declared=preview, computed=stable
- gcp-functions*.adoc: declared=preview, computed=stable

This validates the need for automated status injection to prevent drift.